### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      include: scope
+      prefix: ci
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      include: scope
+      prefix: fix
+      prefix-development: chore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,4 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       include: scope
-      prefix: fix
-      prefix-development: chore
+      prefix: chore


### PR DESCRIPTION
### Description

This PR adds a basic Dependabot configuration to keep `github-actions` as well as npm packages up to date on a weekly schedule.
The config allows up to 10 update PRs to be opened per package-ecosystem and formats the PR titles like this:

* `ci(deps): bump actions/my-action from x to y`
* `fix(deps): bump yamljs from x to y` 
* `chore(dev-deps): bump eslint from 7.24.0 to 7.28.0`

> I am up for suggestions on changing these or removing this formatting altogether :wink: 

### Changes

* adds a basic [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates) config

### Issues

* relates to #3 
