### PR TITLE
Update README for valid color formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ This is how it would end up looking:
 ]
 ```
 
+Note that `color` may be specified in either `000000` or `'#000000'` format. Mind the quotes when using yaml.
+
 If you want to see an actual config file, you can check out the one in this repo [here](.github/labels.yml).
 
 This action can either read a local file or fetch it from a custom URL.  


### PR DESCRIPTION
The `'#000000'` format was added to [github-label-sync v2.0.2](https://github.com/Financial-Times/github-label-sync/tree/v2.0.2) via https://github.com/Financial-Times/github-label-sync/pull/153, which this project is using.