### PR TITLE
Update to use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: An action that allows you to sync labels from a repository or a con
 author: Federico Grandi <federicograndi@duck.com>
 
 runs:
-  using: node16
+  using: node20
   main: lib/index.js
 
 inputs:


### PR DESCRIPTION
Use node20 per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
